### PR TITLE
fixing issue with lucky shard update incompatibilities with teeplate

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,6 +7,7 @@ dependencies:
     github: kostya/cron_parser
   future:
     github: crystal-community/future.cr
+    version: ~> 1.0.0
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
`Unable to satisfy the following requirements:

- `future (branch master)` required by `teeplate 0.8.3`
- `future (~> 1.0.0)` required by `tasker 2.0.5+git.commit.129ab30fdc0e96846e041f8345d003b995803a12`
Failed to resolve dependencies
`

a new lucky project is running into this when doing a shards update.    I think the following will fix but it is a little difficult to test.